### PR TITLE
build-package: with -i -q, ignore recommended packages and suggestions [ci skip]

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -412,6 +412,8 @@ termux_step_start_build() {
 		export TERMUX_APT=" \
 			-o APT::Get::Assume-Yes=true \
 			-o APT::Get::ReInstall=true
+			-o APT::Get::Install-Recommends=false \
+			-o APT::Get::Install-Suggests=false \
 			-o APT::Architecture=${TERMUX_ARCH} \
 			-o Dir::Etc=${TERMUX_PREFIX}/etc/apt/ \
 			-o Dir::State=${TERMUX_PREFIX}/var/lib/apt \


### PR DESCRIPTION
Can speed up builds a bit.

The intention was to have it solve problem with circular dependencies as well but it seems that some other change is necessary (maybe in buildorder.py). 

Some more background: texlive-bin recommends texlive, which in turns depends on texlive-bin. This caused texlive-bin to be downloaded instead of built when running `build-package -q -i -a arm texlive-bin`. 